### PR TITLE
Typo in docs?

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ The add-on API framework allows you load third-party add-on API's. It can also h
 
 #### Example A - Using the Channel Data Library
 
-	$this->EE->load->driver('channel_data');
+	$this->EE->load->library('channel_data');
 
 	$channels 	= $this->EE->channel_data->get_channels();
 	$entries    = $this->EE->channel_data->get_entries();


### PR DESCRIPTION
Hey, shouldn't it be $this->EE->load->library() and not $this->EE->load->driver()?
