### PR TITLE
Bugfix + specifying array of $channel_id's in get_entries()

### DIFF
--- a/Channel_data/Channel_data_lib.php
+++ b/Channel_data/Channel_data_lib.php
@@ -871,11 +871,13 @@ if(!class_exists('Channel_data_lib'))
 
 			// If the channel_id is not false then only the specified channel fields are
 			// appended to the query. Otherwise, all fields are appended.
-
-			$where_array = array('channel_data.channel_id' => $channel_id);
-
+			
+			// also, restrict the query to the specified channel_id in the $where_array
+			
 			if($channel_id !== FALSE)
 			{
+				$where_array = array('channel_data.channel_id' => $channel_id);
+			
 				$fields	 = $this->get_channel_fields($channel_id)->result();
 
 				if(is_array($where))

--- a/Channel_data/Channel_data_lib.php
+++ b/Channel_data/Channel_data_lib.php
@@ -126,7 +126,7 @@ if(!class_exists('Channel_data_lib'))
 		public function build_operators($where = array(), $protect_identifiers = TRUE)
 		{			
 			$where_sql = array();
-			
+			$concat = '';
 			foreach($where as $field => $values)
 			{
 				$field_name = $field;

--- a/Channel_data/Channel_data_lib.php
+++ b/Channel_data/Channel_data_lib.php
@@ -873,17 +873,19 @@ if(!class_exists('Channel_data_lib'))
 			// appended to the query. Otherwise, all fields are appended.
 			
 			// also, restrict the query to the specified channel_id in the $where_array
-			
+
+            $where_array = array();
 			if($channel_id !== FALSE)
 			{
-				$where_array = array('channel_data.channel_id' => $channel_id);
-			
+                if(!is_array($channel_id)) {
+                    $where_array = array('channel_data.channel_id' => $channel_id);
+                }
+
 				$fields	 = $this->get_channel_fields($channel_id)->result();
 
-				if(is_array($where))
-					$where_array = array_merge($where_array, $where);
-				else
-					$where_array = array();
+				if(is_array($where)) {
+                    $where_array = array_merge($where_array, $where);
+                }
 			}
 			else
 			{
@@ -962,6 +964,10 @@ if(!class_exists('Channel_data_lib'))
 
 			$this->convert_params($params, FALSE, FALSE, FALSE, FALSE, FALSE, $debug);
 
+            if(is_array($channel_id))
+            {
+                $this->EE->db->where_in('channel_data.channel_id', $channel_id);
+            }
 
 			return $this->EE->db->get('channel_titles');
 		}

--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ The add-on API framework allows you load third-party add-on API's. It can also h
 
 #### Example A - Using the Channel Data Library
 
-	$this->EE->load->library('channel_data');
+	$this->EE->load->driver('channel_data');
 
 	$channels 	= $this->EE->channel_data->get_channels();
 	$entries    = $this->EE->channel_data->get_entries();

--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ The add-on API framework allows you load third-party add-on API's. It can also h
 
 #### Example A - Using the Channel Data Library
 
-	$this->EE->load->driver('channel_data');
+	$this->EE->load->library('channel_data');
 
 	$channels 	= $this->EE->channel_data->get_channels();
 	$entries    = $this->EE->channel_data->get_entries();

--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ The add-on API framework allows you load third-party add-on API's. It can also h
 
 #### Example B - Loading Channel Data drivers
 	
-	$this->EE->load->channel_data->api->load('gmap');
+	$this->EE->channel_data->api->load('gmap');
 
 	$location = $this->EE->channel_data->gmap->geocode('MT Elbert');
 


### PR DESCRIPTION
Bugfix: I noticed using ->get_entries() would produce SQL where channel_id=0.

Feature: I've implemented so that $channel_id can be an array of channel_ids (or a single $channel_id as before)
