### PR TITLE
Fix "ambiguous column name" error

### DIFF
--- a/Channel_data/Channel_data_lib.php
+++ b/Channel_data/Channel_data_lib.php
@@ -999,7 +999,7 @@ if(!class_exists('Channel_data_lib'))
 		 * @return	object
 		 */
 
-		public function get_members($select = array('members.member_id', 'members.group_id', 'members.email', 'members.username', 'members.screen_name'), $where = array(), $order_by = 'member_id', $sort = 'DESC', $limit = FALSE, $offset = 0)
+		public function get_members($select = array('members.member_id', 'members.group_id', 'members.email', 'members.username', 'members.screen_name'), $where = array(), $order_by = 'members.member_id', $sort = 'DESC', $limit = FALSE, $offset = 0)
 		{
 
 			$fields 		= $this->get_member_fields()->result();


### PR DESCRIPTION
Getting "ambiguous column name" error on the get_members function
